### PR TITLE
fix(intents): consolidate en-US volume intent templates with grammar

### DIFF
--- a/locale/en-US/volume.default.intent
+++ b/locale/en-US/volume.default.intent
@@ -1,7 +1,4 @@
-default volume
-medium volume
-reset volume
-restore volume
-set volume level to default
-set volume to default
-set volume to medium
+(set|make|turn|put|change) [the] volume [level] [to] (default|medium|normal|regular) [level]
+(reset|restore) [the] volume [to (default|medium|normal)]
+volume [level] [to] (default|medium|normal|regular) [level]
+(default|medium|normal|regular) volume

--- a/locale/en-US/volume.high.intent
+++ b/locale/en-US/volume.high.intent
@@ -1,6 +1,3 @@
-high volume
-volume high
-volume level high
-volume level to high
-volume to high
-volume to high level
+(set|make|turn|put|change) [the] volume [level] [to] high [level]
+volume [level] [to] high [level]
+high volume [please]

--- a/locale/en-US/volume.low.intent
+++ b/locale/en-US/volume.low.intent
@@ -1,5 +1,3 @@
-low volume
-volume level low
-volume level to low
-volume low
-volume to low
+(set|make|turn|put|change) [the] volume [level] [to] low [level]
+volume [level] [to] low [level]
+low volume [please]

--- a/locale/en-US/volume.max.intent
+++ b/locale/en-US/volume.max.intent
@@ -1,5 +1,5 @@
-max volume
-maximum volume
-set volume level to maximum
-set volume to maximum
-top volume
+(set|make|turn|put|change) [the] volume [level] [to] (max|maximum|full|highest|top) [level]
+volume [level] [to] (max|maximum|full|highest|top) [level]
+(max|maximum|full|highest|top) volume
+(crank|max) [the] volume [up]
+turn [the] volume all the way up

--- a/locale/en-US/volume.mute.intent
+++ b/locale/en-US/volume.mute.intent
@@ -1,3 +1,2 @@
+(mute|silence) [the] (volume|audio|sound)
 mute
-mute audio
-mute volume

--- a/locale/en-US/volume.mute.toggle.intent
+++ b/locale/en-US/volume.mute.toggle.intent
@@ -1,2 +1,1 @@
-toggle audio
-toggle mute
+toggle [the] (mute|muting|audio|sound|volume)

--- a/locale/en-US/volume.unmute.intent
+++ b/locale/en-US/volume.unmute.intent
@@ -1,3 +1,3 @@
+(unmute|un-mute) [the] (volume|audio|sound)
 unmute
-unmute audio
-unmute volume
+turn [the] (volume|audio|sound) back on


### PR DESCRIPTION
## What
Rewrites the en-US padatious intent templates using OVOS-INTENT-1 grammar (`(a|b)` alternation, `[optional]` tokens) instead of near-duplicate literal lines.

## Coverage added
- **high/low/default/max**: leading verbs `set|make|turn|put|change`, optional `the`/`level`/`to` fillers; synonyms `normal|regular` (default), `full|highest|top` + `crank ... up` + `turn the volume all the way up` (max).
- **mute/unmute**: accept `volume|audio|sound` object; unmute also `turn the sound back on`.
- **toggle**: accept `mute|muting|audio|sound|volume` object.

## Not swallowing other skills
Every template keeps a required lexical anchor (`volume`, or a `mute`/`toggle` verb). The generic word `sound` is deliberately **not** added to the adapt `volume.voc` used by the query/louder/quieter intents, since `current_volume` (`require(volume).optionally(current)`) would then grab "play a sound" / "make a sound". Inside mute/unmute/toggle padatious templates `sound` is safe because a mute verb is always required.

No `.blacklist` added: no template exposes a `{slot}` a deictic/pronoun could wrongly fill (numeric amounts are parsed in code from the raw utterance, not via a slot), so there is no concrete misclassification to exclude.

## Testing
- ovos-padatious trained over the new templates: 17/17 representative utterances route correctly.
- `test/unittests/test_skill_loading.py`: 2 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)